### PR TITLE
Add enable_ssm variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ module "jumphost_profile" {
   }
 }
 ```
-
 ## Requirements
 
 | Name | Version |
@@ -96,16 +95,19 @@ No modules.
 | [aws_iam_role.profile](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.extra](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.profile](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_policy.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 | [aws_iam_policy_document.assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_enable_ssm"></a> [enable\_ssm](#input\_enable\_ssm) | Add AmazonSSMManagedInstanceCore policy to the instance role to grant an EC2 instance the minimum set of permissions needed to use AWS Systems Manager (SSM) core functionality. | `bool` | `true` | no |
 | <a name="input_extra_policies"></a> [extra\_policies](#input\_extra\_policies) | A map of additional policy ARNs to attach to the instance role | `map(string)` | `{}` | no |
 | <a name="input_permissions"></a> [permissions](#input\_permissions) | A JSON with a permissions policy. Note, a new policy will be created with these permissions. | `any` | n/a | yes |
 | <a name="input_profile_name"></a> [profile\_name](#input\_profile\_name) | Instance profile name. | `string` | n/a | yes |
-| <a name="input_role_name"></a> [role\_name](#input\_role\_name) | Profile role name. If given, it will be used. Otherwise, the profile name will be used a name prefix. | `string` | `null` | no |
+| <a name="input_role_name"></a> [role\_name](#input\_role\_name) | Profile role name. If given, it will be used. Otherwise, the profile name will be used as a name prefix. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to resources. | `map` | `{}` | no |
 | <a name="input_upstream_module"></a> [upstream\_module](#input\_upstream\_module) | Module that called this module. | `string` | `null` | no |
 

--- a/data_sources.tf
+++ b/data_sources.tf
@@ -10,3 +10,7 @@ data "aws_iam_policy_document" "assume" {
     actions = ["sts:AssumeRole"]
   }
 }
+
+data "aws_iam_policy" "ssm" {
+  name = "AmazonSSMManagedInstanceCore"
+}

--- a/main.tf
+++ b/main.tf
@@ -35,3 +35,9 @@ resource "aws_iam_role_policy_attachment" "extra" {
   policy_arn = each.value
   role       = aws_iam_role.profile.name
 }
+
+resource "aws_iam_role_policy_attachment" "ssm" {
+  count = var.enable_ssm ? 1 : 0
+  policy_arn = data.aws_iam_policy.ssm.arn
+  role       = aws_iam_role.profile.name
+}

--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,7 @@ resource "aws_iam_role_policy_attachment" "extra" {
 }
 
 resource "aws_iam_role_policy_attachment" "ssm" {
-  count = var.enable_ssm ? 1 : 0
+  count      = var.enable_ssm ? 1 : 0
   policy_arn = data.aws_iam_policy.ssm.arn
   role       = aws_iam_role.profile.name
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,7 @@
 variable "enable_ssm" {
   description = "Add AmazonSSMManagedInstanceCore policy to the instance role to grant an EC2 instance the minimum set of permissions needed to use AWS Systems Manager (SSM) core functionality."
-  type = bool
-  default = true
+  type        = bool
+  default     = true
 }
 variable "extra_policies" {
   description = "A map of additional policy ARNs to attach to the instance role"

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,8 @@
+variable "enable_ssm" {
+  description = "Add AmazonSSMManagedInstanceCore policy to the instance role to grant an EC2 instance the minimum set of permissions needed to use AWS Systems Manager (SSM) core functionality."
+  type = bool
+  default = true
+}
 variable "extra_policies" {
   description = "A map of additional policy ARNs to attach to the instance role"
   type        = map(string)


### PR DESCRIPTION
* The variable makes the module attach a required policy to run SSM
  agent on the instance
* By default it's True, but can be disabled.
