### PR TITLE
feat!: grant ec2:DescribeTags by default; drop AWS provider 5.x

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,8 +51,8 @@ generated with git-cliff (`cliff.toml`) from conventional commits.
 
 `tests/test_module.py` uses the `terraform_apply` fixture from pytest-infrahouse to apply the root config in
 `test_data/instance-profile/`, which calls the module via `source = "../../"`. The test **overwrites**
-`test_data/instance-profile/terraform.tf` and `terraform.tfvars` at runtime (it's parametrized over AWS
-provider versions `~> 5.11` and `~> 6.0`, and over short/128-char-truncated profile names), so don't treat the
+`test_data/instance-profile/terraform.tf` and `terraform.tfvars` at runtime (it's parametrized over the AWS
+provider version `~> 6.0` and over short/128-char-truncated profile names), so don't treat the
 committed contents of those files as authoritative.
 
 ### Git hooks and generated files

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ module "named_profile" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.11, < 7.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.59.0 |
 
 ## Modules
 
@@ -213,6 +213,7 @@ No modules.
 | [aws_iam_role_policy_attachment.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_policy.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 | [aws_iam_policy_document.assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
@@ -220,7 +221,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_enable_ssm"></a> [enable\_ssm](#input\_enable\_ssm) | Add AmazonSSMManagedInstanceCore policy to the instance role to grant an EC2 instance the minimum set of permissions needed to use AWS Systems Manager (SSM) core functionality. | `bool` | `true` | no |
 | <a name="input_extra_policies"></a> [extra\_policies](#input\_extra\_policies) | A map of additional policy ARNs to attach to the instance role | `map(string)` | `{}` | no |
-| <a name="input_permissions"></a> [permissions](#input\_permissions) | A JSON with a permissions policy. Note, a new policy will be created with these permissions. | `string` | n/a | yes |
+| <a name="input_permissions"></a> [permissions](#input\_permissions) | A JSON with a permissions policy. Note, a new policy will be created with these permissions.<br/>The module adds ec2:DescribeTags to the given permissions - the CloudWatch agent<br/>and Auto Scaling lifecycle tooling need it, and it cannot be scoped to a resource. | `string` | n/a | yes |
 | <a name="input_profile_name"></a> [profile\_name](#input\_profile\_name) | Instance profile name. | `string` | n/a | yes |
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | Profile role name. If given, it will be used. Otherwise, the profile name will be used as a name prefix. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to resources. | `map(string)` | `{}` | no |

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ module "named_profile" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.11, < 7.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0, < 7.0 |
 
 ## Providers
 

--- a/data_sources.tf
+++ b/data_sources.tf
@@ -14,3 +14,21 @@ data "aws_iam_policy_document" "assume" {
 data "aws_iam_policy" "ssm" {
   name = "AmazonSSMManagedInstanceCore"
 }
+
+# Caller-supplied permissions merged with defaults every EC2 instance needs.
+#
+# ec2:DescribeTags is granted by default because standard instance tooling
+# depends on it: the CloudWatch agent's ec2tagger reads the
+# aws:autoscaling:groupName tag to populate the AutoScalingGroupName metric
+# dimension, and ASG lifecycle tooling discovers the instance's own ASG the
+# same way. The action is read-only and does not support resource-level
+# permissions (AWS API limitation), so it must be granted on "*".
+# https://github.com/infrahouse/terraform-aws-instance-profile/issues/30
+data "aws_iam_policy_document" "permissions" {
+  source_policy_documents = [var.permissions]
+
+  statement {
+    actions   = ["ec2:DescribeTags"]
+    resources = ["*"]
+  }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,7 +20,7 @@ graph TD
 | Resource | Purpose |
 |----------|---------|
 | `aws_iam_role.profile` | The role EC2 instances assume. Trust policy allows `ec2.amazonaws.com` to call `sts:AssumeRole`. |
-| `aws_iam_policy.profile` | Permissions policy created from the `permissions` JSON input. |
+| `aws_iam_policy.profile` | Permissions policy created from the `permissions` JSON input, plus a default `ec2:DescribeTags` statement. |
 | `aws_iam_instance_profile.profile` | The instance profile that carries the role; its name is what you reference from EC2. |
 | `aws_iam_role_policy_attachment.profile` | Attaches the permissions policy to the role. |
 | `aws_iam_role_policy_attachment.extra` | One attachment per entry in `extra_policies` (`for_each`). |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,6 +36,14 @@ module "profile" {
 }
 ```
 
+!!! note
+    The module automatically adds `ec2:DescribeTags` to the supplied permissions.
+    Standard instance tooling depends on it — the CloudWatch agent's ec2tagger reads
+    the `aws:autoscaling:groupName` tag to populate the `AutoScalingGroupName` metric
+    dimension, and Auto Scaling lifecycle tooling discovers the instance's own ASG the
+    same way. The action is read-only and cannot be scoped to a resource
+    (AWS API limitation).
+
 ## Optional Inputs
 
 ### `enable_ssm`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,7 @@ This guide walks you through deploying your first instance profile with the modu
 
 ## Prerequisites
 
-- **Terraform** with the AWS provider `>= 5.11, < 7.0`.
+- **Terraform** with the AWS provider `>= 6.0, < 7.0`.
 - **AWS credentials** with permissions to manage IAM resources:
   `iam:CreateRole`, `iam:CreatePolicy`, `iam:CreateInstanceProfile`,
   `iam:AttachRolePolicy`, `iam:AddRoleToInstanceProfile`, `iam:TagRole`,

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -54,6 +54,19 @@ the SSM agent — it caches credentials:
 sudo systemctl restart amazon-ssm-agent # or snap.amazon-ssm-agent.amazon-ssm-agent
 ```
 
+## `ec2tagger: Unable to describe ec2 tags` in the CloudWatch agent log
+
+```text
+ec2tagger: Unable to describe ec2 tags for initial retrieval
+UnauthorizedOperation: You are not authorized to perform this operation.
+```
+
+The CloudWatch agent's ec2tagger needs `ec2:DescribeTags` to resolve the
+`AutoScalingGroupName` metric dimension. The module grants this permission by default,
+so if you see this error, the instance is running a profile created by an older module
+version — upgrade the module and re-apply, or add the action to your `permissions`
+document.
+
 ## `MalformedPolicyDocument` on apply
 
 ```text

--- a/examples/basic/terraform.tf
+++ b/examples/basic/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.11, < 7.0"
+      version = ">= 6.0, < 7.0"
     }
   }
 }

--- a/examples/extra-policies/terraform.tf
+++ b/examples/extra-policies/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.11, < 7.0"
+      version = ">= 6.0, < 7.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 resource "aws_iam_policy" "profile" {
   # expected length of name_prefix to be in the range (1 - 102)
   name_prefix = substr(var.profile_name, 0, 102)
-  policy      = var.permissions
+  policy      = data.aws_iam_policy_document.permissions.json
   tags        = local.default_module_tags
 }
 

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.11, < 7.0"
+      version = ">= 6.0, < 7.0"
     }
   }
 }

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -11,10 +11,31 @@ from tests.conftest import (
 )
 
 
+def simulate_action(iam_client, role_arn: str, action: str) -> str:
+    """
+    Evaluate whether the role's attached policies allow an action.
+
+    :param iam_client: Boto3 IAM client.
+    :param role_arn: ARN of the IAM role to evaluate.
+    :param action: IAM action name, e.g. ``ec2:DescribeTags``.
+    :return: IAM evaluation decision: ``allowed``, ``implicitDeny``, or ``explicitDeny``.
+    """
+    response = iam_client.simulate_principal_policy(
+        PolicySourceArn=role_arn,
+        ActionNames=[action],
+    )
+    return response["EvaluationResults"][0]["EvalDecision"]
+
+
 @pytest.mark.parametrize("aws_provider_version", ["~> 5.11", "~> 6.0"])
 @pytest.mark.parametrize("profile_name", ["foo", "very-long-name" * 10])
 def test_module(
-    aws_provider_version, profile_name, aws_region, test_role_arn, keep_after
+    aws_provider_version,
+    profile_name,
+    aws_region,
+    test_role_arn,
+    keep_after,
+    iam_client,
 ):
     terraform_module_dir = osp.join(TERRAFORM_ROOT_DIR, "instance-profile")
 
@@ -56,3 +77,15 @@ def test_module(
         json_output=True,
     ) as tf_output:
         LOG.info("%s", json.dumps(tf_output, indent=4))
+        role_arn = tf_output["role_arn"]["value"]
+
+        # The module grants ec2:DescribeTags by default (issue #30):
+        # needed by the CloudWatch agent's ec2tagger and ASG lifecycle tooling.
+        assert simulate_action(iam_client, role_arn, "ec2:DescribeTags") == "allowed"
+
+        # Guard against over-granting: the module must not add permissions
+        # beyond what the caller passed plus the documented defaults.
+        assert (
+            simulate_action(iam_client, role_arn, "ec2:DescribeVolumes")
+            == "implicitDeny"
+        )

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -27,7 +27,7 @@ def simulate_action(iam_client, role_arn: str, action: str) -> str:
     return response["EvaluationResults"][0]["EvalDecision"]
 
 
-@pytest.mark.parametrize("aws_provider_version", ["~> 5.11", "~> 6.0"])
+@pytest.mark.parametrize("aws_provider_version", ["~> 6.0"], ids=["aws-6"])
 @pytest.mark.parametrize("profile_name", ["foo", "very-long-name" * 10])
 def test_module(
     aws_provider_version,

--- a/variables.tf
+++ b/variables.tf
@@ -22,7 +22,11 @@ variable "role_name" {
 }
 
 variable "permissions" {
-  description = "A JSON with a permissions policy. Note, a new policy will be created with these permissions."
+  description = <<-EOT
+    A JSON with a permissions policy. Note, a new policy will be created with these permissions.
+    The module adds ec2:DescribeTags to the given permissions - the CloudWatch agent
+    and Auto Scaling lifecycle tooling need it, and it cannot be scoped to a resource.
+  EOT
   type        = string
 }
 


### PR DESCRIPTION
## What

Two changes, one release (major — `2.0.0` via `make release-major`):

### feat: grant `ec2:DescribeTags` to the instance role by default

Closes #30

The caller-supplied `permissions` JSON is now merged (via `source_policy_documents`) with a default `ec2:DescribeTags` statement. Rationale:

- The CloudWatch agent's **ec2tagger** requires it to resolve the `AutoScalingGroupName` metric dimension (the ASG name only exists as the `aws:autoscaling:groupName` instance tag, not in IMDS).
- **ASG lifecycle tooling** discovers the instance's own ASG the same way.
- The action is read-only and does not support resource-level permissions (AWS API limitation), so `"*"` is the only possible resource — every consumer (jumphost, openvpn, tetra-data, chromium build runner, Grafana roles) was hand-rolling the identical statement.

Deliberately **not** included after review:
- `ec2:DescribeVolumes` — only needed for the agent's EBS volume-ID dimensions, which the fleet-standard agent config doesn't use; workload-specific needs stay in the caller's `permissions`.
- `CloudWatchAgentServerPolicy` attachment — grants account-wide `logs:PutRetentionPolicy`/`logs:CreateLogGroup`/`PutMetricData` writes; InfraHouse modules scope agent writes to their own log groups instead.

### feat!: drop AWS provider 5.x support

**BREAKING**: the module now requires AWS provider `>= 6.0, < 7.0`. AWS 5.x is being deprecated across InfraHouse modules. The test matrix targets `~> 6.0` only (`ids=["aws-6"]`) per the Terraform Module Requirements — also fixes the test harness failure where provider 6.x writes resource-identity data into shared state that a subsequent 5.x case cannot decode.

## Testing

New assertions in `test_module` use `iam:SimulatePrincipalPolicy` against the created role:

- `ec2:DescribeTags` → `allowed` (verified red before the fix, green after)
- `ec2:DescribeVolumes` → `implicitDeny` (guards against over-granting)

`make test-keep` run: **2 passed** on `aws-6`, resources destroyed cleanly. checkov 33/0, `terraform validate` clean (root + both examples).

🤖 Generated with [Claude Code](https://claude.com/claude-code)